### PR TITLE
Another bugfix for 1-channel edge case

### DIFF
--- a/R/PeacoQC_helper_functions.R
+++ b/R/PeacoQC_helper_functions.R
@@ -458,7 +458,7 @@ FindEventsPerBin <- function(remove_zeros, ff,
   nr_events <- nrow(ff)
 
   if (remove_zeros == TRUE){
-    max_bins_mass <- min(apply(flowCore::exprs(ff)[,channels], 2,
+    max_bins_mass <- min(apply(flowCore::exprs(ff)[,channels, drop = FALSE], 2,
                           function(x)sum(x != 0)))/min_cells
 
     if (max_bins_mass < max_bins){


### PR DESCRIPTION
Hi again @AnneliesEmmaneel. As I continued testing, I noticed that the edge case of a single channel had one more issue when `remove_zeros = TRUE` and traced it down to `FindEventsPerBin`. It's another simple `drop = FALSE` fix. I also did a quick scan of all of the R code for any other cases where there is columnar subsetting with problematic assumptions of > 1 column and didn't see any, so hopefully this is the last one.

Thanks!