### PR TITLE
corrected bug in isolationTreeSD 

### DIFF
--- a/R/PeacoQC_helper_functions.R
+++ b/R/PeacoQC_helper_functions.R
@@ -283,7 +283,7 @@ isolationTreeSD <- function(x, max_depth=as.integer(ceiling(log2(nrow(x)))),
     selection <- matrix(TRUE, ncol=nrow(x))
 
 
-    nodes_to_split <- which(res$to_split == TRUE)
+    nodes_to_split <- which(res$to_split)
 
     while(length(nodes_to_split) > 0){
 
@@ -352,10 +352,20 @@ isolationTreeSD <- function(x, max_depth=as.integer(ceiling(log2(nrow(x)))),
                 max_node <- nrow(res)
                 left_id <- max_node + 1
                 right_id <- max_node + 2
-                res[node, c("left_child", "right_child", "gain",
-                            "split_column", "split_value", "to_split")] <- c(
-                                left_id, right_id, gain_max,
-                                colnames(x)[split_col], split_value, FALSE)
+                # the following commented statement had as side effect that
+                # the whole dataframe was converted to character
+                # (because use of c() which creates a vector => same type)
+                # res[node, c("left_child", "right_child", "gain",
+                #             "split_column", "split_value", "to_split")] <- c(
+                #                 left_id, right_id, gain_max,
+                #                 colnames(x)[split_col], split_value, FALSE)
+                res[node, "left_child"] <- left_id
+                res[node, "right_child"] <- right_id
+                res[node, "gain"] <- gain_max
+                res[node, "split_column"] <- colnames(x)[split_col]
+                res[node, "split_value"] <- split_value
+                res[node, "to_split"] <- FALSE
+                
                 gain_limit <- gain_max
                 res <- rbind(res,
                             data.frame(id=c(left_id, right_id),
@@ -386,7 +396,7 @@ isolationTreeSD <- function(x, max_depth=as.integer(ceiling(log2(nrow(x)))),
 
         }
 
-        nodes_to_split <- which(res$to_split == TRUE)
+        nodes_to_split <- which(res$to_split)
 
     }
 


### PR DESCRIPTION
The bug was leading to error message : 
_Error in which(res$to_split) : argument to 'which' is not logical_
(See Issue #8 )