### PR TITLE
Fix IT_limit default in PeacoQC.R description

### DIFF
--- a/R/PeacoQC.R
+++ b/R/PeacoQC.R
@@ -259,7 +259,7 @@ RemoveDoublets <- function(ff,
 #' Default is calculated based on the rows in \code{ff}
 #' @param MAD The MAD parameter. Default is 6. If this is increased, the
 #' algorithm becomes less strict.
-#' @param IT_limit The IsolationTree parameter. Default is 0.55. If this is
+#' @param IT_limit The IsolationTree parameter. Default is 0.6. If this is
 #' increased, the algorithm becomes less strict.
 #' @param consecutive_bins If 'good' bins are located between bins that are
 #' removed, they will also be marked as 'bad'. The default is 5.


### PR DESCRIPTION
Thanks a lot for the package! 
Found a little error in the docs: The default IT_limit is described as 0.55, should be 0.6 instead